### PR TITLE
Add version number 7.1 for future eveH5 file schema

### DIFF
--- a/bessyhdfviewer.vfs/lib/app-bessyhdfviewer/bessyhdfviewer.tcl
+++ b/bessyhdfviewer.vfs/lib/app-bessyhdfviewer/bessyhdfviewer.tcl
@@ -3208,7 +3208,8 @@ namespace eval BessyHDFViewer {
 			4.0 -
 			5.0 -
 			6   -
-			7  {
+			7   -
+			7.1 {
 				set path [list data $chain data main data]
 				set optpath [list data $chain data snapshot data]
 				set subfieldpaths [list $chain/main/standarddev $chain/main/averagemeta]


### PR DESCRIPTION
This "fix" should not affect any functionality of the BessyHDFViewer, but allow for reading (future) eveH5 files with schema version 7.1 (rather than 7). This schema should only differ by a few new attributes of the root group of the HDF5 file for version 7.1.